### PR TITLE
Fix TypeError

### DIFF
--- a/cvejob/utils.py
+++ b/cvejob/utils.py
@@ -63,7 +63,16 @@ def get_javascript_versions(package):
         logger.error('Unable to fetch versions for package {pkg_name}'.format(pkg_name=package))
         return []
 
-    versions = {x for x in response.json().get('versions')}
+    response_json = {}
+    try:
+        response_json = response.json()
+    except ValueError:
+        pass
+    finally:
+        if not response_json:
+            return []
+
+    versions = {x for x in response_json.get('versions', {})}
 
     return list(versions)
 


### PR DESCRIPTION
Fix for https://github.com/fabric8-analytics/cvejob/issues/32.

Fixes:
Traceback (most recent call last):
  File "run.py", line 57, in <module>
    run()
  File "run.py", line 43, in run
    winner = selector.pick_winner()
  File "/home/jenkins/workspace/cve-job-npm/cvejob/selectors/basic.py", line 40, in pick_winner
    upstream_versions = self._get_upstream_versions(package)
  File "/home/jenkins/workspace/cve-job-npm/cvejob/selectors/basic.py", line 73, in _get_upstream_versions
    return get_javascript_versions(package)
  File "/home/jenkins/workspace/cve-job-npm/cvejob/utils.py", line 66, in get_javascript_versions
    versions = {x for x in response.json().get('versions')}
TypeError: 'NoneType' object is not iterable