### PR TITLE
Migrate to new version of nvdlib

### DIFF
--- a/cvejob/config.py
+++ b/cvejob/config.py
@@ -13,8 +13,11 @@ class DefaultConfig(object):
     # 0 = disable this option and process all CVEs
     cve_age = 0
 
-    # location of the NVD JSON feed
-    feed_path = 'nvdcve.json'
+    # location of the default NVD JSON feeds
+    feed_dir = 'nvd-data/'
+
+    # path to the default NVD JSON feed
+    feed_names = None
 
     # ID of a CVE to process, all other CVEs will be ignored
     cve_id = None
@@ -47,9 +50,13 @@ class RuntimeConfig(object):
         if cve_age is not None:
             self._config.cve_age = int(cve_age)
 
-        feed_path = os.environ.get('CVEJOB_FEED_PATH')
-        if feed_path is not None:
-            self._config.feed_path = feed_path
+        feed_dir = os.environ.get('CVEJOB_FEED_DIR')
+        if feed_dir is not None:
+            self._config.feed_dir = feed_dir
+
+        feed_names = os.environ.get('CVEJOB_FEED_NAMES')
+        if feed_names is not None:
+            self._config.feed_names = ','.split(feed_names)
 
         cve_id = os.environ.get('CVEJOB_CVE_ID')
         if cve_id is not None:

--- a/cvejob/identifiers/__init__.py
+++ b/cvejob/identifiers/__init__.py
@@ -5,7 +5,7 @@ Identifiers are responsible for identifying package name candidates.
 
 from cvejob.config import Config
 from cvejob.identifiers.basic import NaivePackageNameIdentifier
-from cvejob.identifiers.nvdtoolkit import NvdToolkitPackageNameIdentifier
+# from cvejob.identifiers.nvdtoolkit import NvdToolkitPackageNameIdentifier
 
 
 def get_identifier(cve):
@@ -13,5 +13,10 @@ def get_identifier(cve):
     if not Config.use_nvdtoolkit:
         cls = NaivePackageNameIdentifier
     else:
-        cls = NvdToolkitPackageNameIdentifier
+        raise NotImplementedError(
+            "Identifier 'nvd-toolkit' is currently disabled due to nvdlib version incompatibility."
+            " See nvd-toolkit migration status at:"
+            " https://github.com/fabric8-analytics/fabric8-analytics-nvd-toolkit"
+        )
+        # cls = NvdToolkitPackageNameIdentifier
     return cls(cve)

--- a/cvejob/identifiers/nvdtoolkit.py
+++ b/cvejob/identifiers/nvdtoolkit.py
@@ -30,7 +30,7 @@ class NvdToolkitPackageNameIdentifier(NaivePackageNameIdentifier):
         )
 
         results = pipeline.fit_predict(
-            [self._cve.description], classifier__sample=True
+            [self._doc.description], classifier__sample=True
         ).tolist()[0]
 
         candidates = [x[0][0] for x in results]

--- a/cvejob/outputs/victims.py
+++ b/cvejob/outputs/victims.py
@@ -43,10 +43,12 @@ affected:
 
     @property
     def winner(self):
+        """Return winner."""
         return self._winner
 
     @property
     def candidates(self):
+        """Return candidates."""
         return self._candidates
 
     def _makedirs(self):

--- a/cvejob/utils.py
+++ b/cvejob/utils.py
@@ -160,7 +160,7 @@ def get_cpe(doc, cpe_type: str = None) -> list:
 
     if type_to_check:
         cpe_list = list(filter(
-            lambda cpe: eval(f"cpe.is_{type_to_check}()"),
+            lambda _cpe: eval(f"_cpe.is_{type_to_check}()"),
             cpe_list
         ))
 

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -3,4 +3,4 @@
 set -e
 set -x
 
-docker run -ti --rm -v $(pwd):/cvejob/:z -v $(pwd)/nvdlib/nvdlib:/usr/lib/python3.6/site-packages/nvdlib $@ fabric8-analytics/cvejob python3.6 run.py
+docker run -ti --rm -v $(pwd):/cvejob/:z $@ fabric8-analytics/cvejob python3.6 run.py

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -3,4 +3,4 @@
 set -e
 set -x
 
-docker run -ti --rm -v $(pwd):/cvejob/:z $@ fabric8-analytics/cvejob python3.6 run.py
+docker run -ti --rm -v $(pwd):/cvejob/:z -v $(pwd)/nvdlib/nvdlib:/usr/lib/python3.6/site-packages/nvdlib $@ fabric8-analytics/cvejob python3.6 run.py

--- a/get_nvd.sh
+++ b/get_nvd.sh
@@ -10,8 +10,22 @@ set -x
 feed='modified'
 [ -n "$1" ] && feed=$1
 
-url="https://static.nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-$feed.json.gz"
+json_feed="nvdcve-1.0-${feed}.json"
+metadata="nvdcve-1.0-${feed}.meta"
 
-curl -sL ${url} | gunzip - > nvdcve.json
+feed_dir='nvd-data'
+
+mkdir -p "${feed_dir}"
+
+meta_url="https://static.nvd.nist.gov/feeds/json/cve/1.0/${metadata}"
+json_url="https://static.nvd.nist.gov/feeds/json/cve/1.0/${json_feed}.gz"
+
+# metadata
+meta_output_file="${feed_dir}/${metadata}"
+curl -sL ${meta_url} > "${meta_output_file}"
+
+# json
+json_output_file="${feed_dir}/${json_feed}"
+curl -sL ${json_url} | gunzip - > "${json_output_file}"
 
 echo "Successfully downloaded $feed NVD data feed."

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ requests
 beautifulsoup4
 numpy
 scipy
-git+https://github.com/msrb/nvdlib.git#egg=nvdlib
+git+https://github.com/fabric8-analytics/nvdlib.git#egg=nvdlib
 git+https://github.com/fabric8-analytics/fabric8-analytics-nvd-toolkit.git#egg=toolkit

--- a/run.py
+++ b/run.py
@@ -1,9 +1,13 @@
 """Run CVEjob."""
 
-import json
+import os
+import re
+
 import logging
 
-from nvdlib.model import CVE
+import multiprocessing
+
+from nvdlib.manager import FeedManager
 
 from cvejob.filters.input import validate_cve
 from cvejob.config import Config
@@ -11,54 +15,113 @@ from cvejob.identifiers import get_identifier
 from cvejob.selectors.basic import VersionExistsSelector
 from cvejob.outputs.victims import VictimsYamlOutput
 
-logging.basicConfig(level=logging.INFO)
+
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger('cvejob')
+
+FEED_NAME_PATTERN = r"nvdcve-" \
+                    r"(?P<version>[\d.]+)-" \
+                    r"(?P<name>(?P<name_string>(([A-Za-z]+)))|(?P<name_year>([\d]+)))" \
+                    r".json"
 
 
 def run():
     """Run CVEjob."""
-    with open(Config.feed_path, encoding='utf-8') as f:
+    feed_dir = Config.feed_dir
+    feed_names = Config.feed_names
+
+    if not feed_names:
+        # load all feeds in the feed_dir
+
+        feed_names = [
+            f_name for f_name in os.listdir(feed_dir)
+            if re.fullmatch(FEED_NAME_PATTERN, f_name, re.IGNORECASE)
+        ]
+
+        if not feed_names:
+            logger.error("Feeds have not been found in {}".format(feed_dir))
+
+    with FeedManager(n_workers=multiprocessing.cpu_count()) as feed_manager:
+
+        feeds = feed_manager.fetch_feeds(
+            feed_names=feed_names, data_dir=feed_dir
+        )
+        collection = feed_manager.collect(feeds)
+
         cherrypicked_cve_id = Config.cve_id
 
-        feed = json.load(f)
+        if cherrypicked_cve_id:
+            logger.debug("Cherry-picked CVE `{cve_id}`".format(
+                cve_id=cherrypicked_cve_id
+            ))
+            collection = collection.find(
+                {'cve.id_': cherrypicked_cve_id}
+            )
+            logger.debug("Number of CVE Documents in the collection: {}".format(
+                collection.count()
+            ))
 
-        for cve_dict in feed.get('CVE_Items'):
-            cve = CVE.from_dict(cve_dict)
-            logger.info('{cve_id} found'.format(cve_id=cve.cve_id))
+            if not collection:  # collection is empty
+                logger.info(
+                    "[{picked_cve_id}] was not found in the collection of feeds:"
+                    "{feed_names}".format(
+                        picked_cve_id=cherrypicked_cve_id,
+                        feed_names=feed_names
+                    ))
+
+                return
+
+        for doc in collection:
+
+            cve_id = doc.cve.id_
 
             try:
-                if cherrypicked_cve_id and cve.cve_id != cherrypicked_cve_id:
-                    # we are only interested in the cherry-picked CVE ID
-                    logger.info('{cve_id} not cherry-picked, skipping')
+
+                if not validate_cve(doc):
+                    logger.debug(
+                        "[{cve_id}] was filtered out by input checks".format(
+                            cve_id=cve_id
+                        ))
                     continue
 
-                if not validate_cve(cve):
-                    logger.info(
-                        '{cve_id} was filtered out by input checks'.format(cve_id=cve.cve_id)
-                    )
-                    continue
-
-                identifier = get_identifier(cve)
+                identifier = get_identifier(doc)
                 candidates = identifier.identify()
 
                 if not candidates:
                     logger.info(
-                        '{cve_id} no package name candidates found'.format(cve_id=cve.cve_id)
-                    )
+                        "[{cve_id}] no package name candidates found".format(
+                            cve_id=cve_id
+                        ))
                     continue
 
-                selector = VersionExistsSelector(cve, candidates)
+                print('Candidates:', candidates)
+
+                selector = VersionExistsSelector(doc, candidates)
                 winner = selector.pick_winner()
 
                 if not winner:
-                    logger.info('{cve_id} no package name found'.format(cve_id=cve.cve_id))
+                    logger.info(
+                        "[{cve_id}] no package name found".format(
+                            cve_id=cve_id
+                        ))
                     continue
 
-                VictimsYamlOutput(cve, winner, candidates).write()
-            finally:
-                if cherrypicked_cve_id and cve.cve_id == cherrypicked_cve_id:
-                    # we found what we were looking for, skip the rest
-                    break
+                victims_output = VictimsYamlOutput(doc, winner, candidates)
+                victims_output.write()
+
+                logger.info(
+                    "[{cve_id}] picked `{winner}` out of `{candidates}`".format(
+                        cve_id=cve_id,
+                        winner=victims_output.winner,
+                        candidates=victims_output.candidates
+                    ))
+
+            except Exception as exc:
+                logger.warning("[{cve_id}]Unexpected exception occured: "
+                               "{exc}".format(
+                                cve_id=cve_id,
+                                exc=exc
+                               ))
 
 
 if __name__ == '__main__':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 import json
-from nvdlib.model import CVE
+from nvdlib.model import Document
 
 from cvejob.config import DefaultConfig
 
@@ -11,8 +11,8 @@ from cvejob.config import DefaultConfig
 def javascript_cve():
     """JavaScript CVE fixture."""
     with open('tests/data/javascript-nvdcve.json') as f:
-        nvd_json = json.load(f)
-        return CVE.from_dict(nvd_json['CVE_Items'][0])
+        data, = json.load(f)['CVE_Items']
+        return Document.from_data(data)
 
 
 @pytest.fixture


### PR DESCRIPTION
nvdlib:
- https://github.com/fabric8-analytics/nvdlib

changes:
- temporarily disable nvd-toolkit due to nvdlib incompatibility

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   cvejob/config.py
modified:   cvejob/filters/input.py
modified:   cvejob/identifiers/__init__.py
modified:   cvejob/identifiers/basic.py
modified:   cvejob/identifiers/nvdtoolkit.py
modified:   cvejob/outputs/victims.py
modified:   cvejob/selectors/basic.py
modified:   cvejob/utils.py
modified:   docker-run.sh
modified:   get_nvd.sh
modified:   requirements.txt
modified:   run.py
modified:   tests/conftest.py