### PR TITLE
Correctly handle untracked files when opening pull requests

### DIFF
--- a/open_pull_requests.sh
+++ b/open_pull_requests.sh
@@ -50,8 +50,7 @@ echo "Merging cvejob-local database with the upstream database..."
 cp -r ${data}/* ${cvedb}/database/
 
 # get list of new/modified files in the upstream database
-files=$(cd ${cvedb} && git status -s | awk '{ print $2 }')
-
+files=$(cd ${cvedb} && git status -s -u | awk '{ print $2 }')
 
 # iterate over all new/modified files in the upstream database and open PRs
 echo "Opening pull requests..."


### PR DESCRIPTION
Previously the PR title was wrong for new YAML files which were added to
previously untracked directories.