### PR TITLE
capital words regex logic updated

### DIFF
--- a/cvejob/identifiers/naive.py
+++ b/cvejob/identifiers/naive.py
@@ -77,7 +77,11 @@ class NaivePackageNameIdentifier(object):
             nltk.download('stopwords')
             stop_words.update(stopwords.words('english'))
 
-        regexp = re.compile('[A-Z][A-Za-z0-9-:]*')
+        # modified the logic to include keywords that have capital letter anywhere,
+        # not necessarily as the first character.
+        # Also, two words separated by hyphen are also important,
+        # even when there are no capital letters
+        regexp = re.compile('[A-Za-z0-9-:]*[A-Z][A-Za-z0-9-:]*|[A-Za-z0-9]+[-][A-Za-z0-9]+')
         suspects = regexp.findall(sentence)
 
         results = [x.lower() for x in suspects if x.lower() not in stop_words]


### PR DESCRIPTION
Modified the logic to include keywords that have capital letter anywhere, not necessarily as the first character.
Also, two words separated by hyphen are also important, even when there are no capital letters.